### PR TITLE
Adjustments to Swagger UI colors to match our new dark theme.

### DIFF
--- a/layouts/shortcodes/console.html
+++ b/layouts/shortcodes/console.html
@@ -25,7 +25,6 @@
         body
         {
             margin:0;
-            background: #fafafa;
         }
     </style>
 </head>

--- a/static/css/theme-newspaper.css
+++ b/static/css/theme-newspaper.css
@@ -43,7 +43,6 @@
   cursor: pointer;
   -webkit-transition: all .2s;
   transition: all .2s;
-  border-bottom: 1px solid rgba(59, 65, 81, .3);
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center
@@ -102,8 +101,6 @@
 
 .swagger-ui .opblock {
   margin: 0 0 15px;
-  border: 1px solid #000;
-  border-radius: 4px;
   box-shadow: 0 0 3px rgba(0, 0, 0, .19)
 }
 
@@ -112,9 +109,7 @@
 }
 
 .swagger-ui .opblock .opblock-section-header {
-  padding: 8px 20px;
-  background: hsla(0, 0%, 100%, .8);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, .1)
+  padding: 20px 20px;
 }
 
 .swagger-ui .opblock .opblock-section-header, .swagger-ui .opblock .opblock-section-header label {
@@ -141,6 +136,7 @@
 .swagger-ui .opblock .opblock-section-header h4 {
   font-size: 14px;
   margin: 0;
+  padding-right: 10px;
   -webkit-box-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -200,7 +196,7 @@
   -ms-flex: 1;
   flex: 1;
   font-family: Open Sans, sans-serif;
-  color: #3b4151
+  color: #ccc
 }
 
 .swagger-ui .opblock .opblock-summary {
@@ -421,7 +417,7 @@
 .swagger-ui .response-col_status {
   font-size: 14px;
   font-family: Open Sans, sans-serif;
-  color: #3b4151
+  color: #cccccc
 }
 
 .swagger-ui .response-col_status .response-undocumented {
@@ -467,7 +463,7 @@
 .swagger-ui .scheme-container {
   margin: 0 0 20px;
   padding: 30px 0;
-  background: #fff;
+  background: #222222;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, .15)
 }
 
@@ -575,7 +571,6 @@
   transition: all .3s;
   border: 2px solid #888;
   border-radius: 4px;
-  background: transparent;
   box-shadow: 0 1px 2px rgba(0, 0, 0, .1);
   font-family: Titillium Web, sans-serif;
   color: #3b4151
@@ -725,10 +720,11 @@
   background-size: 20px;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, .25);
   font-family: Titillium Web, sans-serif;
-  color: #3b4151;
   -webkit-appearance: none;
   -moz-appearance: none;
-  appearance: none
+  appearance: none;
+  background-color: #666;
+  color: #ccc;
 }
 
 .swagger-ui select[multiple] {
@@ -738,7 +734,7 @@
 }
 
 .swagger-ui .opblock-body select {
-  min-width: 230px
+  min-width: 230px;
 }
 
 .swagger-ui label {
@@ -755,7 +751,8 @@
   padding: 8px 10px;
   border: 1px solid #d9d9d9;
   border-radius: 4px;
-  background: #fff
+  background-color: #666;
+  color: #ccc;
 }
 
 .swagger-ui input[type=email].invalid, .swagger-ui input[type=password].invalid, .swagger-ui input[type=search].invalid, .swagger-ui input[type=text].invalid {
@@ -979,7 +976,6 @@
   font-weight: 300;
   font-family: Source Code Pro, monospace;
   font-weight: 600;
-  color: #3b4151
 }
 
 .swagger-ui .model-toggle {
@@ -1055,7 +1051,8 @@
 
 .swagger-ui section.models.is-open h4 {
   margin: 0 0 5px;
-  border-bottom: 1px solid rgba(59, 65, 81, .3)
+  border-bottom: 1px solid rgba(59, 65, 81, .3);
+  background-color: #222222;
 }
 
 .swagger-ui section.models.is-open h4 svg {
@@ -1077,7 +1074,8 @@
   color: #777;
   -webkit-box-align: center;
   -ms-flex-align: center;
-  align-items: center
+  align-items: center;
+  background-color: #222222;
 }
 
 .swagger-ui section.models h4 svg {
@@ -1092,7 +1090,7 @@
 }
 
 .swagger-ui section.models h4:hover {
-  background: rgba(0, 0, 0, .02)
+  background-color: #444444;
 }
 
 .swagger-ui section.models h5 {
@@ -1112,11 +1110,11 @@
   -webkit-transition: all .5s;
   transition: all .5s;
   border-radius: 4px;
-  background: rgba(0, 0, 0, .05)
+  background-color: #222222;
 }
 
 .swagger-ui section.models .model-container:hover {
-  background: rgba(0, 0, 0, .07)
+  background-color: #222222;
 }
 
 .swagger-ui section.models .model-container:first-of-type {
@@ -1145,7 +1143,7 @@
 .swagger-ui .model-title {
   font-size: 16px;
   font-family: Titillium Web, sans-serif;
-  color: #555
+  color: #cccccc;
 }
 
 .swagger-ui span>span.model, .swagger-ui span>span.model .brace-close {
@@ -1167,7 +1165,8 @@
 .swagger-ui table {
   width: 100%;
   padding: 0 10px;
-  border-collapse: collapse
+  border-collapse: collapse;
+  border-color: #666666;
 }
 
 .swagger-ui table.model tbody tr td {
@@ -1190,13 +1189,14 @@
 }
 
 .swagger-ui table tbody tr td {
-  padding: 10px 0 0;
-  vertical-align: top
+  padding: 10px 10px
+  vertical-align: top;
+  border-color: #666666;
 }
 
 .swagger-ui table tbody tr td:first-of-type {
   width: 20%;
-  padding: 10px 0
+  padding: 10px 10px
 }
 
 .swagger-ui table thead tr td, .swagger-ui table thead tr th {
@@ -1206,14 +1206,16 @@
   text-align: left;
   border-bottom: 1px solid rgba(59, 65, 81, .2);
   font-family: Open Sans, sans-serif;
-  color: #3b4151
+  color: #cccccc;
+  background-color: #444;
+  border-color: #666666;
 }
 
 .swagger-ui .parameters-col_description p {
   font-size: 14px;
   margin: 0;
   font-family: Open Sans, sans-serif;
-  color: #3b4151
+  color: #888888
 }
 
 .swagger-ui .parameters-col_description input[type=text] {
@@ -1225,7 +1227,7 @@
   font-size: 16px;
   font-weight: 400;
   font-family: Titillium Web, sans-serif;
-  color: #3b4151
+  color: #cccccc;
 }
 
 .swagger-ui .parameter__name.required {
@@ -1542,11 +1544,11 @@
 
  .swagger-ui .opblock.opblock-post {
    border-color: #DADFE1;
-   background: rgba(34, 34, 34, .1);
+   background: rgba(34, 34, 34, 1);
  }
 
  .swagger-ui .opblock.opblock-post .opblock-summary-method {
-   background: #222222;
+   background: #444444;
  }
 
  .swagger-ui .opblock.opblock-post .opblock-summary {
@@ -1581,15 +1583,15 @@
 
  .swagger-ui .opblock.opblock-get {
    border-color: #DADFE1;
-   background: rgba(34, 34, 34, .1);
+   background: rgba(34, 34, 34, 1);
  }
 
  .swagger-ui .opblock.opblock-get .opblock-summary-method {
-   background: #222222;
+   background: #444444;
  }
 
  .swagger-ui .opblock.opblock-get .opblock-summary {
-   border-color: #DADFE1;
+   border-color: #222222;
  }
 
  .swagger-ui .opblock.opblock-patch {


### PR DESCRIPTION
Firstly, I failed to find a theme that better fit our dark color coding.
[Swagger UI theme screenshots](https://github.com/ostranme/swagger-ui-themes/tree/develop/screenshots/3.x)

So did minor adjustments to the theme-newspaper.css to resolve any problematic text/background colors (e.g. grey on grey).

This patch resolves the most critical issues found on the API console page.

Resolves issue: https://github.com/MagnumOpuses/jobtechdev.se/issues/10