### PR TITLE
Fix typo in Swedish navigation bar, 'Öpen källkod' -> 'Öppen källkod'.

### DIFF
--- a/i18n/sv.toml
+++ b/i18n/sv.toml
@@ -11,7 +11,7 @@ other = "START"
 other = "APIER"
 
 [nav-open-source]
-other = "ÖPEN KÄLLKOD"
+other = "ÖPPEN KÄLLKOD"
 
 [nav-about-us]
 other = "OM OSS"


### PR DESCRIPTION
Fix issue: https://github.com/MagnumOpuses/jobtechdev.se/issues/27
