### PR TITLE
Fix notice box text color

### DIFF
--- a/static/css/theme-mine.css
+++ b/static/css/theme-mine.css
@@ -29,9 +29,7 @@ body {
     color: var(--MAIN-TEXT-color) !important;
     background-color:var(--MAIN-BACKGROUND-color) ;
 }
-strong {
-    color: var(--MAIN-TITLES-TEXT-color) !important;
-}
+
 textarea:focus, input[type="email"]:focus, input[type="number"]:focus, input[type="password"]:focus, input[type="search"]:focus, input[type="tel"]:focus, input[type="text"]:focus, input[type="url"]:focus, input[type="color"]:focus, input[type="date"]:focus, input[type="datetime"]:focus, input[type="datetime-local"]:focus, input[type="month"]:focus, input[type="time"]:focus, input[type="week"]:focus, select[multiple=multiple]:focus {
     border-color: none;
     box-shadow: none;

--- a/static/css/theme-mine.css
+++ b/static/css/theme-mine.css
@@ -36,6 +36,7 @@ textarea:focus, input[type="email"]:focus, input[type="number"]:focus, input[typ
 }
 
 h1, h2, h3, h4, h5 {
+    color: #ccc; /* Fallback for IE */
     color: var(--MAIN-TITLES-TEXT-color) !important;
 }
 


### PR DESCRIPTION
**What does this implement/fix?**

Changes the color of **bolded** texts from `#ccc` to `#666`.

![font-color-new](https://user-images.githubusercontent.com/7243912/60089846-a21d2c00-9741-11e9-9f2f-e230e4297726.png)

**Does this close any currently open issues?**

Fixes https://github.com/MagnumOpuses/jobtechdev.se/issues/36

**Any relevant logs, error output, etc?**

N/A

**Any other comments?**

This is how the original colors looked:
![font-color-old](https://user-images.githubusercontent.com/7243912/60090093-240d5500-9742-11e9-93f5-e113a34f7b1f.png)

**Where has this been tested?**
 - **Device:** Laptop
 - **OS:** Windows 10
 - **Browser:** Chrome, IE
