### PR TITLE
Removed vacancies module from Showcases.

### DIFF
--- a/content/open_source/showcases/_index.md
+++ b/content/open_source/showcases/_index.md
@@ -32,17 +32,6 @@
         },
         {
           "type": "Widget",
-          "name": "Vacancies",
-          "description": "Showing the candidates by location.",
-          "links":[
-            {
-              "name":"Source code",
-              "url":"https://github.com/jobtechdev/vacancieswidget"
-            }
-            ]
-        },
-        {
-          "type": "Widget",
           "name": "Job",
           "description": "This widget suggests jobs based on the personal data already available in the context in which the widget is placed.",
           "links":[


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**

Simply removes the "Vacancies" showcase because it's out-dated.

**Does this close any currently open issues?**

Fixes: https://github.com/MagnumOpuses/jobtechdev.se/issues/41

**Any relevant logs, error output, etc?**

N/A

**Any other comments?**

N/A

**Where has this been tested?**
 - **Device:** Laptop
 - **OS:** Windows 10
 - **Browser:** Chrome
 