### PR TITLE
Added changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2019-06-27
+
+### Added
+- Cookie policy and cookie banner on front page and documentation pages (https://github.com/MagnumOpuses/jobtechdev.se/pull/39)
+- Readme instructions on how to build/run site in 'stage'-mode (https://github.com/MagnumOpuses/jobtechdev.se/pull/23)
+- New event 'Tech for lunch!' (https://github.com/MagnumOpuses/jobtechdev.se/pull/25)
+- Information about closure of old YrkesInfo & RAF API (https://github.com/MagnumOpuses/jobtechdev.se/pull/24)
+- 'Theos'-styled pull-request template (https://github.com/MagnumOpuses/jobtechdev.se/pull/22, https://github.com/MagnumOpuses/jobtechdev.se/pull/33)
+
+### Fixed
+- Revapi not defined error (https://github.com/MagnumOpuses/jobtechdev.se/pull/38)
+- Menu sliding bug in IE (https://github.com/MagnumOpuses/jobtechdev.se/pull/35)
+- Featherlight popup to be dark themed (https://github.com/MagnumOpuses/jobtechdev.se/pull/44)
+
+### Changed
+- Upgraded Hugo to v0.55 (https://github.com/MagnumOpuses/jobtechdev.se/pull/34)
+- Upgraded Hugo-theme-learn to v2.3.0 (https://github.com/MagnumOpuses/jobtechdev.se/pull/34)
+- Fixed typo in swedish navbar (https://github.com/MagnumOpuses/jobtechdev.se/pull/31)
+- Darkened the bold text in notice boxes (https://github.com/MagnumOpuses/jobtechdev.se/pull/37)
+- Swagger UI theme to better fit Jobtechdev's dark themed website (https://github.com/MagnumOpuses/jobtechdev.se/pull/18)
+- Upgraded PDF.js to v2.1.266 (https://github.com/MagnumOpuses/jobtechdev.se/pull/42)
+
+### Removed
+- Removed 'Vacancies' showcase (https://github.com/MagnumOpuses/jobtechdev.se/pull/43)
+
+### Security
+- CSP rule to allow image sources from 'online.swagger.io' (https://github.com/MagnumOpuses/jobtechdev.se/pull/32)
+- CSP rule to allow blob image sources from whitelisted domains (https://github.com/MagnumOpuses/jobtechdev.se/pull/42)


### PR DESCRIPTION
# Changelog

All notable changes to this project will be documented in this file.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## [Unreleased]

## [1.0.0] - 2019-06-27

### Added
- Cookie policy and cookie banner on front page and documentation pages (https://github.com/MagnumOpuses/jobtechdev.se/pull/39)
- Readme instructions on how to build/run site in 'stage'-mode (https://github.com/MagnumOpuses/jobtechdev.se/pull/23)
- New event 'Tech for lunch!' (https://github.com/MagnumOpuses/jobtechdev.se/pull/25)
- Information about closure of old YrkesInfo & RAF API (https://github.com/MagnumOpuses/jobtechdev.se/pull/24)
- 'Theos'-styled pull-request template (https://github.com/MagnumOpuses/jobtechdev.se/pull/22, https://github.com/MagnumOpuses/jobtechdev.se/pull/33)

### Fixed
- Revapi not defined error (https://github.com/MagnumOpuses/jobtechdev.se/pull/38)
- Menu sliding bug in IE (https://github.com/MagnumOpuses/jobtechdev.se/pull/35)
- Featherlight popup to be dark themed (https://github.com/MagnumOpuses/jobtechdev.se/pull/44)

### Changed
- Upgraded Hugo to v0.55 (https://github.com/MagnumOpuses/jobtechdev.se/pull/34)
- Upgraded Hugo-theme-learn to v2.3.0 (https://github.com/MagnumOpuses/jobtechdev.se/pull/34)
- Fixed typo in swedish navbar (https://github.com/MagnumOpuses/jobtechdev.se/pull/31)
- Darkened the bold text in notice boxes (https://github.com/MagnumOpuses/jobtechdev.se/pull/37)
- Swagger UI theme to better fit Jobtechdev's dark themed website (https://github.com/MagnumOpuses/jobtechdev.se/pull/18)
- Upgraded PDF.js to v2.1.266 (https://github.com/MagnumOpuses/jobtechdev.se/pull/42)

### Removed
- Removed 'Vacancies' showcase (https://github.com/MagnumOpuses/jobtechdev.se/pull/43)

### Security
- CSP rule to allow image sources from 'online.swagger.io' (https://github.com/MagnumOpuses/jobtechdev.se/pull/32)
- CSP rule to allow blob image sources from whitelisted domains (https://github.com/MagnumOpuses/jobtechdev.se/pull/42)
