### PR TITLE
Removed the JobScanner preview links

### DIFF
--- a/content/open_source/showcases/_index.md
+++ b/content/open_source/showcases/_index.md
@@ -88,10 +88,6 @@
           "description": "The JobScanner shows the potential and power of collecting all the recruitment needs of the labour market in one place. Please note that it's current in demo and operates on historical data. We plan to populate it with live data early fall 2019.",
           "links":[
             {
-              "name":"Preview",
-              "url":"https://jobscanner.jobtechdev.se/"
-            },
-            {
               "name":"Source code",
               "url":"https://github.com/MagnumOpuses/JobScanning"
             }

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -346,7 +346,6 @@
                                 <h3 class="w3-tilte">{{ i18n "projcards-jobscanner-title" }}</h3>
                                 <p>{{ i18n "projcards-jobscanner-body" }}</p>
                                 <div class="button-code">
-                                    <a href="https://jobscanner.jobtechdev.se" class="site-button outline white m-r15">{{ i18n "try-it" }}</a>
                                     <a href="/open_source/showcases/#scanner" class="site-button outline white m-r15">{{ i18n "read-more" }}</a>
                                 </div>
                             </div>


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**

Removed the JobScanner preview links from both splash screen and showcases page, due to the service temporarily being unavailable.

**Does this close any currently open issues?**

N/A

**Any relevant logs, error output, etc?**

![removed-splash-jobscanner-try-it](https://user-images.githubusercontent.com/7243912/60523087-6c041d00-9cea-11e9-87e6-8216ea6edf98.png)
![removed-jobscanner-showcase-preview](https://user-images.githubusercontent.com/7243912/60523088-6dcde080-9cea-11e9-9467-2a28aeea0c46.png)


**Any other comments?**

N/A

**Where has this been tested?**
 - **Device:** Laptop
 - **OS:** Windows 10
 - **Browser:** Chrome
 