### PR TITLE
Corrected weights on most pages to avoid page order ambiguity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Mydata github links pointed to old repo fixed
 - Broken link to AF Jobs Swagger UI (https://github.com/MagnumOpuses/jobtechdev.se/pull/56)
+- Weights on most pages to avoid page order ambiguity in left-hand menu.
 
 ### Removed
 - Unnecessary/Duplicated Swagger files (https://github.com/MagnumOpuses/jobtechdev.se/pull/56)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Mydata github links pointed to old repo fixed
 - Broken link to AF Jobs Swagger UI (https://github.com/MagnumOpuses/jobtechdev.se/pull/56)
-- Weights on most pages to avoid page order ambiguity in left-hand menu.
+- Weights on most pages to avoid page order ambiguity in left-hand menu (https://github.com/MagnumOpuses/jobtechdev.se/pull/61)
 
 ### Removed
 - Unnecessary/Duplicated Swagger files (https://github.com/MagnumOpuses/jobtechdev.se/pull/56)

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -2,7 +2,7 @@
 title: "About us"
 date: 2018-01-28T21:58:09+01:00
 chapter: true
-weight: 1
+weight: 10
 
 ---
 # About us

--- a/content/about/openbydefault/_index.md
+++ b/content/about/openbydefault/_index.md
@@ -2,7 +2,7 @@
 title: "Open by default"
 date: 2018-01-28T21:58:09+01:00
 #anchor: "API"
-weight: 3
+weight: 30
 # Table of content (toc) is enabled by default. Set this parameter to true to disable it.
 # Note: Toc is always disabled for chapter pages
 disableToc: "false"

--- a/content/about/vision/_index.md
+++ b/content/about/vision/_index.md
@@ -4,7 +4,7 @@ date: 2018-01-28T21:58:09+01:00
 anchor: "Introduction"
 menuTitle: "Our vision"
 disableToc: true
-weight: 2
+weight: 20
 ---
 
 *An open digital infrastructure that enables people to meet. All actors can easily contribute with their data and code - as well as take part of others'.*

--- a/content/about/whoweare/_index.md
+++ b/content/about/whoweare/_index.md
@@ -2,7 +2,7 @@
 title: "Who we are"
 date: 2018-01-28T21:58:09+01:00
 #anchor: "API"
-weight: 1
+weight: 10
 # Table of content (toc) is enabled by default. Set this parameter to true to disable it.
 # Note: Toc is always disabled for chapter pages
 disableToc: "false"

--- a/content/about/work/_index.md
+++ b/content/about/work/_index.md
@@ -4,7 +4,7 @@ title: "Work with us"
 date: 2018-01-28T21:58:09+01:00
 disableToc: true
 menuTitle: "Work with us"
-weight: 4
+weight: 40
 ---
 ##### A NEW ERA  
 Within JobTech we're constantly challenging old ways of working and old techniques. We're focusing on using all the opportunities new technology can offer to create new, innovative, valuable solutions and assets for the labour market.

--- a/content/api/_index.md
+++ b/content/api/_index.md
@@ -2,7 +2,7 @@
 title: "APIs"
 date: 2018-01-28T21:58:09+01:00
 #anchor: "API"
-weight: 3
+weight: 30
 # Table of content (toc) is enabled by default. Set this parameter to true to disable it.
 # Note: Toc is always disabled for chapter pages
 disableToc: "false"

--- a/content/api/beta/_index.md
+++ b/content/api/beta/_index.md
@@ -2,7 +2,7 @@
 title: "Beta versions"
 date: 2018-01-28T21:58:09+01:00
 #anchor: "beta"
-weight: 11
+weight: 20
 # Table of content (toc) is enabled by default. Set this parameter to true to disable it.
 # Note: Toc is always disabled for chapter pages
 disableToc: "false"

--- a/content/api/beta/jobsearch/_index.md
+++ b/content/api/beta/jobsearch/_index.md
@@ -3,7 +3,7 @@ title: "Job search"
 date: 2018-01-28T21:58:09+01:00
 disableToc: true
 menuTitle: "Job Search"
-weight: 27
+weight: 10
 ---
 
 Our job search API is a search engine for all the current job ads from Platsbanken. 

--- a/content/api/dev_guide/apiconsole/_index.md
+++ b/content/api/dev_guide/apiconsole/_index.md
@@ -2,7 +2,7 @@
 title: "API Console"
 disableToc: true
 menuTitle: "API console"
-weight: 10
+weight: 20
 ---
 
 #### <center>Give our latest technology a test run right here and now!      

--- a/content/api/dev_guide/dev_community/_index.md
+++ b/content/api/dev_guide/dev_community/_index.md
@@ -4,7 +4,7 @@ date: 2019-02-26T15:00:35+01:00
 #anchor: "community"
 menuTitle: "Dev community"
 disableToc: true
-weight: 101
+weight: 30
 ---
 #### The nature of application development has changed. 
 Whether you’re building enterprise applications to manage your most

--- a/content/api/jobs/_index.md
+++ b/content/api/jobs/_index.md
@@ -2,7 +2,7 @@
 title: "Jobs"
 date: 2018-01-28T21:58:09+01:00
 #anchor: "jobs"
-weight: 11
+weight: 30
 # Table of content (toc) is enabled by default. Set this parameter to true to disable it.
 # Note: Toc is always disabled for chapter pages
 disableToc: "false"

--- a/content/api/jobs/jobsearch/_index.md
+++ b/content/api/jobs/jobsearch/_index.md
@@ -3,7 +3,7 @@ title: "Job search"
 date: 2018-01-28T21:58:09+01:00
 disableToc: true
 menuTitle: "Job Search"
-weight: 27
+weight: 10
 ---
 
 Our job search API is a search engine for all the current job ads from Platsbanken. 

--- a/content/api/jobs/platsbanken/_index.md
+++ b/content/api/jobs/platsbanken/_index.md
@@ -3,7 +3,7 @@ title: "Af Jobs"
 date: 2018-01-28T21:58:09+01:00
 disableToc: true
 menuTitle: "Af Jobs"
-weight: 25
+weight: 30
 ---
 
 

--- a/content/api/occupation/_index.md
+++ b/content/api/occupation/_index.md
@@ -2,7 +2,7 @@
 title: "Occupations"
 date: 2018-01-28T21:58:09+01:00
 #anchor: "occupations"
-weight: 12
+weight: 40
 # Table of content (toc) is enabled by default. Set this parameter to true to disable it.
 # Note: Toc is always disabled for chapter pages
 disableToc: "false"

--- a/content/api/occupation/forecasts/_index.md
+++ b/content/api/occupation/forecasts/_index.md
@@ -2,7 +2,7 @@
 title: "Af Occupation Forecast"
 disableToc: true
 menuTitle: "Af Occupation Forecast"
-weight: 30
+weight: 10
 date: 2019-01-19T20:06:16+01:00
 ---
 

--- a/content/api/occupation/occupations/_index.md
+++ b/content/api/occupation/occupations/_index.md
@@ -2,7 +2,7 @@
 title: "Af Occupation info"
 disableToc: true
 menuTitle: "Af Occupation Info"
-weight: 31
+weight: 20
 date: 2019-01-19T20:06:16+01:00
 ---
 

--- a/content/api/occupation/raf/_index.md
+++ b/content/api/occupation/raf/_index.md
@@ -2,7 +2,7 @@
 title: "Af Work Ability"
 menuTitle: "Af Work Ability"
 disableToc: true
-weight: 34
+weight: 30
 date: 2019-01-19T20:06:16+01:00
 ---
 

--- a/content/api/terms/_index.md
+++ b/content/api/terms/_index.md
@@ -2,7 +2,7 @@
 title: "Terminology"
 date: 2018-01-28T21:58:09+01:00
 #anchor: "occupations"
-weight: 13
+weight: 50
 # Table of content (toc) is enabled by default. Set this parameter to true to disable it.
 # Note: Toc is always disabled for chapter pages
 disableToc: "false"

--- a/content/api/terms/ontology/_index.md
+++ b/content/api/terms/ontology/_index.md
@@ -2,7 +2,7 @@
 title: "Ontology"
 menuTitle: "Ontology"
 disableToc: true
-weight: 32
+weight: 20
 date: 2019-01-19T20:06:16+01:00
 ---
 

--- a/content/api/terms/taxonomy/_index.md
+++ b/content/api/terms/taxonomy/_index.md
@@ -2,7 +2,7 @@
 title: "Taxonomy"
 disableToc: true'
 menuTitle: "Taxonomy"
-weight: 33
+weight: 10
 date: 2019-01-19T20:06:16+01:00
 ---
 

--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -3,7 +3,7 @@ title: "Community"
 date: 2019-02-26T14:55:42+01:00
 #anchor: "community"
 chapter: true
-weight: 5
+weight: 50
 ---
 # Community
 <hr>

--- a/content/community/events/_index.md
+++ b/content/community/events/_index.md
@@ -4,7 +4,7 @@ date: 2019-02-26T14:59:02+01:00
 #anchor: "community"
 menuTitle: "Events"
 disableToc: true
-weight: 10
+weight: 20
 ---
 
 ### Happening in JobTech ! ###

--- a/content/cookie_policy/_index.md
+++ b/content/cookie_policy/_index.md
@@ -2,7 +2,7 @@
 title: "Cookie Policy"
 disableToc: true
 date: 2019-01-19T20:06:16+01:00
-weight: 6
+weight: 60
 # Set the page as a chapter, changing the way it's displayed
 chapter: true
 ---

--- a/content/cookie_policy/english/_index.md
+++ b/content/cookie_policy/english/_index.md
@@ -2,7 +2,7 @@
 title: "Cookie Policy (English)"
 disableToc: true
 date: 2019-01-19T20:06:16+01:00
-weight: 6
+weight: 10
 menuTitle: "English"
 ---
 

--- a/content/cookie_policy/swedish/_index.md
+++ b/content/cookie_policy/swedish/_index.md
@@ -2,7 +2,7 @@
 title: "Cookie Policy (Swedish)"
 disableToc: true
 date: 2019-01-19T20:06:16+01:00
-weight: 6
+weight: 20
 menuTitle: "Swedish"
 ---
 

--- a/content/focus_areas/_index.md
+++ b/content/focus_areas/_index.md
@@ -3,7 +3,7 @@ title: "Focus areas"
 date: 2018-01-28T21:58:09+01:00
 #anchor: "API"
 chapter: true
-weight: 2
+weight: 20
 ---
 # Components
 <hr>

--- a/content/focus_areas/common/_index.md
+++ b/content/focus_areas/common/_index.md
@@ -2,7 +2,7 @@
 title: "Taxonomy"
 disableToc: true
 date: 2018-01-28T21:58:09+01:00
-weight: 4
+weight: 40
 ---
 
 The purpose of JobTech Taxonomy is to provide a relevant vocabulary for important elements in the language for the labour market.

--- a/content/focus_areas/jobs/_index.md
+++ b/content/focus_areas/jobs/_index.md
@@ -2,7 +2,7 @@
 title: "Jobs"
 disableToc: true
 date: 2019-01-19T20:06:16+01:00
-weight: 2
+weight: 20
 ---
 
  JobTech jobs collect and provide information about all job postings in Sweden by two methods:

--- a/content/focus_areas/mydata/_index.md
+++ b/content/focus_areas/mydata/_index.md
@@ -2,7 +2,7 @@
 title: "MyData"
 disableToc: true
 date: 2019-01-19T20:06:16+01:00
-weight: 1
+weight: 10
 ---
 
 MyData aims for individuals to have control over their own data.The JobTech MyData goal is a distributed and decentralized data storage for the labour market. Take CV data as an example: It should be accessible for those who have an interest in reading or writing in the data but on the basis that the individual always has control of the information. Massive data sets collected by companies and authorities creates possibility to see patterns in the behavior of people, and create new products and services to create a new value. The data can also be used for other purposes for example monitoring or affect opinions in politics. To control a lot of individual data could mean a risk.

--- a/content/focus_areas/search/_index.md
+++ b/content/focus_areas/search/_index.md
@@ -2,7 +2,7 @@
 title: "Search"
 disableToc: true
 date: 2019-01-19T20:06:16+01:00
-weight: 3
+weight: 30
 ---
 You can improve your job seeking service by using **JobTech search** as your search engine.
 Integrating JobTech search means that you don't need to develop search technology anymore.

--- a/content/open_source/_index.md
+++ b/content/open_source/_index.md
@@ -3,7 +3,7 @@ title: "Open Source"
 date: 2018-01-28T21:58:09+01:00
 menuTitle: "Open Source"
 #anchor: "Open Source"
-weight: 4
+weight: 40
 # Table of content (toc) is enabled by default. Set this parameter to true to disable it.
 # Note: Toc is always disabled for chapter pages
 disableToc: "false"

--- a/content/open_source/papers/_index.md
+++ b/content/open_source/papers/_index.md
@@ -4,7 +4,7 @@ menuTitle: "Papers"
 date: 2019-05-28T10:35:05+01:00
 disableToc: true
 chapter: false
-weight: 103
+weight: 40
 section: false
 ---
 

--- a/content/open_source/research/_index.md
+++ b/content/open_source/research/_index.md
@@ -4,7 +4,7 @@ menuTitle: "Research"
 date: 2018-01-28T21:58:09+01:00
 disableToc: true
 chapter: false
-weight: 101
+weight: 20
 section: false
 ---
 

--- a/content/open_source/showcases/_index.md
+++ b/content/open_source/showcases/_index.md
@@ -2,7 +2,7 @@
     "title": "Showcases",
     "menuTitle": "Showcases",
     "disableToc":"false",
-    "weight": 102,
+    "weight": 30,
     "showcases": [ 
         {
           "type": "Widget",

--- a/content/open_source/tools/_index.md
+++ b/content/open_source/tools/_index.md
@@ -4,7 +4,7 @@ menuTitle: "Tools"
 date: 2018-01-28T21:58:09+01:00
 disableToc: true
 chapter: false
-weight: 100
+weight: 10
 section: false
 ---
 


### PR DESCRIPTION
**What does this implement/fix?**

Fixes the page order ambiguity issue in the docs left-hand navigation menu.

All pages that share the same direct parent SHOULD have unique weights.

**Does this close any currently open issues?**

https://github.com/MagnumOpuses/jobtechdev.se/issues/60

**Any relevant logs, error output, etc?**

N/A

**Any other comments?**

N/A

**Where has this been tested?**
 - **Device:** Laptop
 - **OS:** Windows 10
 - **Browser:** Chrome
 - **Version:** Version 74.0.3729.169 (64 bitar)
 