### PR TITLE
Release 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 None
+## [1.1.2] - 2019-07-15 
+
+### Fixed
+- Seperated Analytics and Tag Mangager accounts.
+- Fixed Content Security spec to support font, analytics and tag manager.  
 
 ## [1.1.1] - 2019-07-15 
 

--- a/prod-nginx.conf
+++ b/prod-nginx.conf
@@ -138,11 +138,11 @@ http {
         set $CSP ""; # to split long string.
         set $CSP "${CSP}default-src 'self'; ";
         set $CSP "${CSP}script-src 'self' 'unsafe-inline' *.google.com *.googletagmanager.com *.google-analytics.com; ";
-        set $CSP "${CSP}style-src 'self' 'unsafe-inline' use.fontawesome.com fonts.googleapis.com; ";
-        set $CSP "${CSP}img-src 'self' blob: *.googletagmanager.com *.google-analytics.com stats.g.doubleclick.net online.swagger.io; ";
+        set $CSP "${CSP}style-src 'self' 'unsafe-inline' use.fontawesome.com fonts.googleapis.com tagmanager.google.com; ";
+        set $CSP "${CSP}img-src 'self' blob: *.googletagmanager.com *.google-analytics.com stats.g.doubleclick.net online.swagger.io *.gstatic.com; ";
         set $CSP "${CSP}connect-src 'self' *.jobtechdev.se; ";
         set $CSP "${CSP}form-action 'none'; ";
-        set $CSP "${CSP}font-src 'self' use.fontawesome.com fonts.googleapis.com fonts.gstatic.com; ";
+        set $CSP "${CSP}font-src 'self' use.fontawesome.com fonts.googleapis.com fonts.gstatic.com  data:; ";
         set $CSP "${CSP}frame-src 'none'; ";
         set $CSP "${CSP}object-src 'none'; ";
         set $CSP "${CSP}frame-ancestors 'none';";

--- a/stage-nginx.conf
+++ b/stage-nginx.conf
@@ -139,11 +139,11 @@ http {
         set $CSP ""; # to split long string.
         set $CSP "${CSP}default-src 'self'; ";
         set $CSP "${CSP}script-src 'self' 'unsafe-inline' *.google.com *.googletagmanager.com *.google-analytics.com; ";
-        set $CSP "${CSP}style-src 'self' 'unsafe-inline' use.fontawesome.com fonts.googleapis.com; ";
-        set $CSP "${CSP}img-src 'self' blob: *.googletagmanager.com *.google-analytics.com stats.g.doubleclick.net online.swagger.io; ";
+        set $CSP "${CSP}style-src 'self' 'unsafe-inline' use.fontawesome.com fonts.googleapis.com tagmanager.google.com; ";
+        set $CSP "${CSP}img-src 'self' blob: *.googletagmanager.com *.google-analytics.com stats.g.doubleclick.net online.swagger.io *.gstatic.com; ";
         set $CSP "${CSP}connect-src 'self' *.jobtechdev.se; ";
         set $CSP "${CSP}form-action 'none'; ";
-        set $CSP "${CSP}font-src 'self' use.fontawesome.com fonts.googleapis.com fonts.gstatic.com; ";
+        set $CSP "${CSP}font-src 'self' data:font use.fontawesome.com fonts.googleapis.com fonts.gstatic.com data:; ";
         set $CSP "${CSP}frame-src 'none'; ";
         set $CSP "${CSP}object-src 'none'; ";
         set $CSP "${CSP}frame-ancestors 'none';";


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the [contribution guidelines](CONTRIBUTING.md), then fill out the blanks below.)

This is the fix for tag manager and content security policy. Some fonts, google analytics/tag manager didn't load. 

**What does this implement/fix? Explain your changes.**

Opens possibility to load from data, analytics and tag manager. 
Organize were to analyze site data


**Does this close any currently open issues?**

#66 #70 

**Any relevant logs, error output, etc?**

...

**Any other comments?**

...

**Where has this been tested?**
 - **Device:** Mac
 - **OS:** IOS
 - **Browser:** Chrome
 - **Version:** Lastest
 